### PR TITLE
fix(ifort): address issue with Intel OneAPI ifort compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ cmake_install.cmake
 *.exe
 lib/
 include/
+build/
+bin/

--- a/src/spatial/m_geometry.f90
+++ b/src/spatial/m_geometry.f90
@@ -161,6 +161,36 @@ module m_geometry
       !! [-ve, 0, +ve] for point d [right, on, left] of the plane defined by points a -> b -> c
     end function
   end interface
+  
+  interface
+    module subroutine fastTwoDiff(a, b, x, y)
+      !! Compute the difference two numbers and compute the numerical round-off error.
+      !! This should only be used if you know that the magnitude of a is greater than or equal to b, otherwise, you should use the slower twoDiff routine
+    !====================================================================!
+      real(r64), intent(in) :: a
+        !! First number
+      real(r64), intent(in) :: b
+        !! Second number
+      real(r64), intent(out) :: x
+        !! Result
+      real(r64), intent(out) :: y
+    end subroutine
+  end interface
+
+  interface
+    module subroutine fastTwoSum(a, b, x, y)
+      !! Compute the sum of two numbers and compute the numerical round-off error.
+      !! This should only be used if you know that the magnitude of a is greater than or equal to b, otherwise, you should use the slower twoSum routine
+    !====================================================================!
+      real(r64), intent(in) :: a
+        !! First number
+      real(r64), intent(in) :: b
+        !! Second number
+      real(r64), intent(out) :: x
+        !! Result
+      real(r64), intent(out) :: y
+    end subroutine
+  end interface
 
   interface
     !====================================================================!


### PR DESCRIPTION
Modified fastTwoDiff and fastTwoSum in order to compile with OneAPI ifort
(2021.5.0 20211109). Added an interface to m_geometry for fastTwoDiff and
fastTwoSum. Prior to modification got the following error

```
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(230): error #6115: A separate interface body must have been declared in the program unit or an ancestor of the program unit for the separate module procedure.   [FASTTWODIFF]
  module subroutine fastTwoDiff(a, b, x, y)
--------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(234): error #6451: A dummy argument name is required in this context.   [A]
    real(r64), intent(in) :: a
-----------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(236): error #6451: A dummy argument name is required in this context.   [B]
    real(r64), intent(in) :: b
-----------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(238): error #6451: A dummy argument name is required in this context.   [X]
    real(r64), intent(out) :: x
------------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(240): error #6451: A dummy argument name is required in this context.   [Y]
    real(r64), intent(out) :: y
------------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(249): error #6115: A separate interface body must have been declared in the program unit or an ancestor of the program unit for the separate module procedure.   [FASTTWOSUM]
  module subroutine fastTwoSum(a, b, x, y)
--------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(253): error #6451: A dummy argument name is required in this context.   [A]
    real(r64), intent(in) :: a
-----------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(255): error #6451: A dummy argument name is required in this context.   [B]
    real(r64), intent(in) :: b
-----------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(257): error #6451: A dummy argument name is required in this context.   [X]
    real(r64), intent(out) :: x
------------------------------^
/Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90(259): error #6451: A dummy argument name is required in this context.   [Y]
    real(r64), intent(out) :: y
------------------------------^
compilation aborted for /Users/jdhughes/Documents/Development/coretran/src/spatial/sm_geometry.f90 (code 1)
make[2]: *** [CMakeFiles/coretran.dir/spatial/sm_geometry.f90.o] Error 1
make[1]: *** [CMakeFiles/coretran.dir/all] Error 2
make: *** [all] Error 2
```

closes #28 reopen issue if sm_maths_d1D.f90 issue still exists